### PR TITLE
Add integration for neorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ local default_config = {
         mason = true,
         navic = false,
         neo_tree = false,
+        neorg = false,
         noice = true,
         notify = true,
         rainbow_delimiters = true,

--- a/lua/oldworld/config.lua
+++ b/lua/oldworld/config.lua
@@ -23,6 +23,7 @@ local default_config = {
         mason = true,
         navic = false,
         neo_tree = false,
+        neorg = false,
         noice = true,
         notify = true,
         rainbow_delimiters = true,

--- a/lua/oldworld/highlights.lua
+++ b/lua/oldworld/highlights.lua
@@ -17,6 +17,7 @@ local groups_highlights = {
     mason = require("oldworld.integrations.mason"),
     navic = require("oldworld.integrations.navic"),
     neo_tree = require("oldworld.integrations.neo_tree"),
+    neorg = require("oldworld.integrations.neorg"),
     noice = require("oldworld.integrations.noice"),
     notify = require("oldworld.integrations.notify"),
     rainbow_delimiters = require("oldworld.integrations.rainbow_delimiters"),

--- a/lua/oldworld/integrations/neorg.lua
+++ b/lua/oldworld/integrations/neorg.lua
@@ -1,0 +1,17 @@
+return {
+    -- Neorg 7 seems to link to some of the 'text.*' highlight groups
+    ["@text.underline"] = { link = "Underlined" },
+    ["@text.strong"] = { bold = true },
+    ["@text.strikethrough"] = { strikethrough = true },
+    ["@text.italic"] = { italic = true },
+
+    -- Neorg 7 links italics to regular text instead of italics
+    ["@neorg.markup.italic.norg"] = { link = "@text.italic" },
+
+    -- Neorg 8 commits to linking to the highlight groups defined by treesitter:
+    -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
+    ["@markup.underline"] = { link = "@text.underline" },
+    ["@markup.strong"] = { link = "@text.strong" },
+    ["@markup.italic"] = { link = "@text.italic" },
+    ["@markup.strikethrough"] = { link = "@text.strikethrough" },
+}


### PR DESCRIPTION
Added an integration for [Neorg](https://github.com/nvim-neorg/neorg) text decorations. Neorg handles highlight group linking differently between versions 7 and 8, I captured both versions here. I think the markup groups should likely be handled in the NormalNvim integration, but I saw that a lot of those are being done in the LSP integration. I didn't want to interfere with those, but let me know if you'd like me to implement differently or refactor to not have the LSP integration responsible for markup groups.
