### PR TITLE
Feature: New extra for Alacritty

### DIFF
--- a/extras/alacritty/oldworld.toml
+++ b/extras/alacritty/oldworld.toml
@@ -1,0 +1,26 @@
+# Default colors
+[colors.primary]
+background = '#161617'
+foreground = '#c9c7cd'
+
+# Normal colors
+[colors.normal]
+black = '#27272a'
+blue = '#92a2d5'
+cyan = '#85b5ba'
+green = '#90b99f'
+magenta = '#e29eca'
+red = '#ea83a5'
+white = '#c9c7cd'
+yellow = '#e6b99d'
+
+# Bright colors
+[colors.bright]
+black = '#353539'
+blue = '#a6b6e9'
+cyan = '#99c9ce'
+green = '#9dc6ac'
+magenta = '#ecaad6'
+red = '#f591b2'
+white = '#c9c7cd'
+yellow = '#f0c5a9'


### PR DESCRIPTION
# Screenshot

![image](https://github.com/dgox16/oldworld.nvim/assets/1554116/9e371016-f5e7-4268-bdbb-c7469fea832d)

# What does this do?

Adds a colorscheme file to the extras folder so you can use the oldworld colorscheme with Alacritty, similarly to #4. The file is based on [another colorscheme as template](https://raw.githubusercontent.com/miikanissi/modus-themes.nvim/master/extras/alacritty/modus_vivendi.toml).