### PR TITLE
Add configuration options to override highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ local default_config = {
         telescope = true,
         treesitter = true,
     },
+    highlight_overrides = {}
 }
 ```
 
@@ -77,6 +78,9 @@ require("oldworld").setup({
         hop = true,
         telescope = false,
     },
+    highlight_overrides = {
+        Comment = { bg = "#ff0000" }
+    }
 })
 ```
 
@@ -86,4 +90,4 @@ It's my first theme and my first Neovim plugin. I know in advance that there wil
 
 ## 🎙️ Acknowledgements
 
--   [mellow.nvim](https://github.com/mellow-theme/mellow.nvim) used its amazing color palette and styles as a base.
+- [mellow.nvim](https://github.com/mellow-theme/mellow.nvim) used its amazing color palette and styles as a base.

--- a/lua/oldworld/config.lua
+++ b/lua/oldworld/config.lua
@@ -1,58 +1,59 @@
 local config = {}
 
 local default_config = {
-    terminal_colors = true,
-    styles = {
-        comments = {},
-        keywords = {},
-        identifiers = {},
-        functions = {},
-        variables = {},
-        booleans = {},
-    },
-    integrations = {
-        alpha = true,
-        cmp = true,
-        flash = true,
-        gitsigns = true,
-        hop = false,
-        indent_blankline = true,
-        lazy = true,
-        lsp = true,
-        markdown = true,
-        mason = true,
-        navic = false,
-        neo_tree = false,
-        neorg = false,
-        noice = true,
-        notify = true,
-        rainbow_delimiters = true,
-        telescope = true,
-        treesitter = true,
-    },
+	terminal_colors = true,
+	styles = {
+		comments = {},
+		keywords = {},
+		identifiers = {},
+		functions = {},
+		variables = {},
+		booleans = {},
+	},
+	integrations = {
+		alpha = true,
+		cmp = true,
+		flash = true,
+		gitsigns = true,
+		hop = false,
+		indent_blankline = true,
+		lazy = true,
+		lsp = true,
+		markdown = true,
+		mason = true,
+		navic = false,
+		neo_tree = false,
+		neorg = false,
+		noice = true,
+		notify = true,
+		rainbow_delimiters = true,
+		telescope = true,
+		treesitter = true,
+	},
+	highlight_overrides = {},
 }
 
 function config.setup(opts)
-    if opts == nil then
-        return
-    end
+	if opts == nil then
+		return
+	end
 
-    for k, v in pairs(opts) do
-        if k == "integrations" then
-            for integration, enabled in pairs(v) do
-                default_config.integrations[integration] = enabled
-            end
-        elseif k == "styles" then
-            for style_key, style_value in pairs(v) do
-                if default_config.styles[style_key] ~= nil then
-                    config.styles[style_key] =
-                        vim.tbl_deep_extend("keep", default_config.styles[style_key], style_value)
-                end
-            end
-        else
-            config[k] = v
-        end
-    end
+	for k, v in pairs(opts) do
+		if k == "integrations" then
+			for integration, enabled in pairs(v) do
+				default_config.integrations[integration] = enabled
+			end
+		elseif k == "styles" then
+			for style_key, style_value in pairs(v) do
+				if default_config.styles[style_key] ~= nil then
+					config.styles[style_key] =
+						vim.tbl_deep_extend("keep", default_config.styles[style_key], style_value)
+				end
+			end
+		else
+			config[k] = v
+		end
+	end
 end
 
 return setmetatable(config, { __index = default_config })

--- a/lua/oldworld/highlights.lua
+++ b/lua/oldworld/highlights.lua
@@ -6,51 +6,54 @@ local terminal = require("oldworld.terminal")
 local M = {}
 
 local integrations_highlights = {
-    alpha = require("oldworld.groups.integrations.alpha"),
-    cmp = require("oldworld.groups.integrations.cmp"),
-    flash = require("oldworld.groups.integrations.flash"),
-    gitsigns = require("oldworld.groups.integrations.gitsigns"),
-    hop = require("oldworld.groups.integrations.hop"),
-    indent_blankline = require("oldworld.groups.integrations.indent_blankline"),
-    lazy = require("oldworld.groups.integrations.lazy"),
-    lsp = require("oldworld.groups.integrations.lsp"),
-    markdown = require("oldworld.groups.integrations.markdown"),
-    mason = require("oldworld.groups.integrations.mason"),
-    navic = require("oldworld.groups.integrations.navic"),
-    neo_tree = require("oldworld.groups.integrations.neo_tree"),
-    neorg = require("oldworld.groups.integrations.neorg"),
-    noice = require("oldworld.groups.integrations.noice"),
-    notify = require("oldworld.groups.integrations.notify"),
-    rainbow_delimiters = require("oldworld.groups.integrations.rainbow_delimiters"),
-    telescope = require("oldworld.groups.integrations.telescope"),
-    treesitter = require("oldworld.groups.integrations.treesitter"),
+	alpha = require("oldworld.groups.integrations.alpha"),
+	cmp = require("oldworld.groups.integrations.cmp"),
+	flash = require("oldworld.groups.integrations.flash"),
+	gitsigns = require("oldworld.groups.integrations.gitsigns"),
+	hop = require("oldworld.groups.integrations.hop"),
+	indent_blankline = require("oldworld.groups.integrations.indent_blankline"),
+	lazy = require("oldworld.groups.integrations.lazy"),
+	lsp = require("oldworld.groups.integrations.lsp"),
+	markdown = require("oldworld.groups.integrations.markdown"),
+	mason = require("oldworld.groups.integrations.mason"),
+	navic = require("oldworld.groups.integrations.navic"),
+	neo_tree = require("oldworld.groups.integrations.neo_tree"),
+	neorg = require("oldworld.groups.integrations.neorg"),
+	noice = require("oldworld.groups.integrations.noice"),
+	notify = require("oldworld.groups.integrations.notify"),
+	rainbow_delimiters = require("oldworld.groups.integrations.rainbow_delimiters"),
+	telescope = require("oldworld.groups.integrations.telescope"),
+	treesitter = require("oldworld.groups.integrations.treesitter"),
 }
 local integrations = {}
 
 for integration, enabled in pairs(config.integrations) do
-    if enabled then
-        local highlights = integrations_highlights[integration]
-        table.insert(integrations, { enabled = true, highlights = highlights })
-    end
+	if enabled then
+		local highlights = integrations_highlights[integration]
+		table.insert(integrations, { enabled = true, highlights = highlights })
+	end
 end
 
 local function load_highlights(highlights)
-    for group_name, group_settings in pairs(highlights) do
-        vim.api.nvim_set_hl(0, group_name, group_settings)
-    end
+	for group_name, group_settings in pairs(highlights) do
+		vim.api.nvim_set_hl(0, group_name, group_settings)
+	end
 end
 
 function M.setup()
-    load_highlights(editor_highlights)
-    load_highlights(syntax_highlights)
-    for _, plugin in ipairs(integrations) do
-        if plugin.enabled then
-            load_highlights(plugin.highlights)
-        end
-    end
-    if config.terminal_colors then
-        terminal.setup()
-    end
+	load_highlights(editor_highlights)
+	load_highlights(syntax_highlights)
+	for _, plugin in ipairs(integrations) do
+		if plugin.enabled then
+			load_highlights(plugin.highlights)
+		end
+	end
+
+	load_highlights(config.highlight_overrides)
+
+	if config.terminal_colors then
+		terminal.setup()
+	end
 end
 
 return M


### PR DESCRIPTION
Love the theme! I've added a simple way to override (or add new) highlight groups in the theme.

## Example

```lua
require("oldworld").setup({
    highlight_overrides = {
        Comment = { bg = "#ff0000" }
    }
})
```

## Future improvements

Although this PR covers the core functionality it might be worth looking into a way of referencing colours from the palette for overrides, perhaps something like this?

```lua
require("oldworld").setup({
    highlight_overrides = function(palette)
        return {
           Comment = { bg = palette.red }
         }
    end
})
```

I've also updated README.md to document these configuration options