### PR TITLE
fix(doc): Use correct variant parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The theme will use the default values unless you change the default configuratio
 ```lua
 local default_config = {
     terminal_colors = true, -- enable terminal colors
-    variants = "default", -- Two variants availables: default and cooler
+    variant = "default", -- Two variants availables: default and cooler
     styles = { -- You can pass the style using the format: style = true
         comments = {}, -- style for comments
         keywords = {}, -- style for keywords


### PR DESCRIPTION
I noticed the README uses `variants` as the parameter in the config, but it looks like it should be `variant` instead.