### PR TITLE
Add CSS colors for waybar config

### DIFF
--- a/extras/waybar/oldworld.css
+++ b/extras/waybar/oldworld.css
@@ -1,0 +1,71 @@
+/* 
+* A port of OldWorld.nvim for use with Waybar
+* Add "@import url("oldworld.css")" to the top of your style.css to use
+*/
+
+@define-color bg rgb(22, 22, 23);
+@define-color bgAlpha rgba(22, 22, 23, 0.4);
+
+@define-color fg rgb(201, 199, 205);
+@define-color fgAlpha rgba(201, 199, 205, 0.4);
+
+@define-color subtext1 rgb(180, 177, 186);
+@define-color subtext1Alpha rgba(180, 177, 186, 0.4);
+
+@define-color subtext2 rgb(159, 156, 166);
+@define-color subtext2Alpha rgba(159, 156, 166, 0.4);
+
+@define-color subtext3 rgb(139, 134, 147);
+@define-color subtext3Alpha rgba(139, 134, 147, 0.4);
+
+@define-color subtext4 rgb(108, 104, 116);
+@define-color subtext4Alpha rgba(108, 104, 116, 0.4);
+
+@define-color bg_dark rgb(19, 19, 20);
+@define-color bg_darkAlpha rgba(19, 19, 20, 0.4);
+
+@define-color black rgb(39, 39, 42);
+@define-color blackAlpha rgba(39, 39, 42, 0.4);
+
+@define-color red rgb(234, 131, 165);
+@define-color redAlpha rgba(234, 131, 165, 0.4);
+
+@define-color green rgb(144, 185, 159);
+@define-color greenAlpha rgba(144, 185, 159, 0.4);
+
+@define-color yellow rgb(230, 185, 157);
+@define-color yellowAlpha rgba(230, 185, 157, 0.4);
+
+@define-color purple rgb(172, 161, 207);
+@define-color purpleAlpha rgba(172, 161, 207, 0.4);
+
+@define-color magenta rgb(226, 158, 202);
+@define-color magentaAlpha rgba(226, 158, 202, 0.4);
+
+@define-color orange rgb(245, 161, 145);
+@define-color orangeAlpha rgba(245, 161, 145, 0.4);
+
+@define-color blue rgb(146, 162, 213);
+@define-color blueAlpha rgba(146, 162, 213, 0.4);
+
+@define-color cyan rgb(133, 181, 186);
+@define-color cyanAlpha rgba(133, 181, 186, 0.4);
+
+@define-color gray0 rgb(24, 24, 26);
+@define-color gray0Alpha rgba(24, 24, 26, 0.4);
+
+@define-color gray1 rgb(27, 27, 28);
+@define-color gray1Alpha rgba(27, 27, 28, 0.4);
+
+@define-color gray2 rgb(42, 42, 44);
+@define-color gray2Alpha rgba(42, 42, 44, 0.4);
+
+@define-color gray3 rgb(49, 49, 52);
+@define-color gray3Alpha rgba(49, 49, 52, 0.4);
+
+@define-color gray4 rgb(59, 59, 62);
+@define-color gray4Alpha rgba(59, 59, 62, 0.4);
+
+@define-color gray5 rgb(68, 68, 72);
+@define-color gray5Alpha rgba(68, 68, 72, 0.4);
+


### PR DESCRIPTION
This PR adds a single css file that contains standard palette colors and alpha variants to be imported into a waybar style.css for use throughout. Should work with any other GTK3 app